### PR TITLE
Remove undesired reset of TinyXML2_FOUND and update TODO

### DIFF
--- a/cmake/Modules/FindTinyXML2.cmake
+++ b/cmake/Modules/FindTinyXML2.cmake
@@ -26,7 +26,7 @@ else()
   mark_as_advanced(TINYXML2_INCLUDE_DIR TINYXML2_LIBRARY)
 endif()
 
-# TODO: Determine if this is necessary with mixed-case find_package_handle_standard_args.
+# Set mixed case INCLUDE_DIRS and LIBRARY variables from upper case ones.
 if(NOT TinyXML2_INCLUDE_DIRS)
   set(TinyXML2_INCLUDE_DIRS ${TINYXML2_INCLUDE_DIR})
 endif()

--- a/cmake/Modules/FindTinyXML2.cmake
+++ b/cmake/Modules/FindTinyXML2.cmake
@@ -24,7 +24,6 @@ else()
   find_package_handle_standard_args(TinyXML2 DEFAULT_MSG TINYXML2_LIBRARY TINYXML2_INCLUDE_DIR)
 
   mark_as_advanced(TINYXML2_INCLUDE_DIR TINYXML2_LIBRARY)
-  set(TinyXML2_FOUND ${tinyxml2_FOUND})
 endif()
 
 # TODO: Determine if this is necessary with mixed-case find_package_handle_standard_args.


### PR DESCRIPTION
I found afbae40 while investigating #4 but I don't believe it's related. fde8000 is follow up from #3.

@jacobperron I couldn't get the full story from commit logs alone. Do you recall why [this change in #2](https://github.com/ros2/tinyxml2_vendor/pull/2/files#diff-120198e331f1dd3e7806c31af0cfb425R27) was introduced?