### PR TITLE
Install the package.xml for use by overlay workspaces

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -13,6 +13,10 @@ configure_file(tinyxml2_vendorConfig-version.cmake.in
 install(DIRECTORY cmake DESTINATION share/${PROJECT_NAME})
 
 install(FILES
+  "${CMAKE_CURRENT_SOURCE_DIR}/package.xml"
+  DESTINATION share/${PROJECT_NAME})
+
+install(FILES
   "${PROJECT_BINARY_DIR}/tinyxml2_vendorConfig.cmake"
   "${PROJECT_BINARY_DIR}/tinyxml2_vendorConfig-version.cmake"
   DESTINATION share/${PROJECT_NAME}/cmake)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -13,7 +13,7 @@ configure_file(tinyxml2_vendorConfig-version.cmake.in
 install(DIRECTORY cmake DESTINATION share/${PROJECT_NAME})
 
 install(FILES
-  "${CMAKE_CURRENT_SOURCE_DIR}/package.xml"
+  package.xml
   DESTINATION share/${PROJECT_NAME})
 
 install(FILES


### PR DESCRIPTION
We need the package.xml to be present in the install space so that we can use rosdep to install the `tinyxml2` key. This is particularly important when we're leveraging a subset of the distributed "fat" archive.