### PR TITLE
Do not call find_package() if package has already been found

### DIFF
--- a/cmake/Modules/FindTinyXML2.cmake
+++ b/cmake/Modules/FindTinyXML2.cmake
@@ -3,7 +3,9 @@
 # TinyXML2_LIBRARIES
 
 # try to find the CMake config file for TinyXML2 first
-find_package(TinyXML2 CONFIG QUIET)
+if(NOT TinyXML2_FOUND)
+  find_package(TinyXML2 CONFIG QUIET)
+endif()
 if(TinyXML2_FOUND)
   message(STATUS "Found TinyXML2 via Config file: ${TinyXML2_DIR}")
   if(NOT TINYXML2_LIBRARY)


### PR DESCRIPTION
This greatly speeds up complex builds, as a lot of time was spent by repeated calls to find_package() from FindTinyXML2.cmake