### PR TITLE
Ensure that find_package(TINYXML2) defines TINYXML2::TINYXML2 even on case insensitive filesystems

### DIFF
--- a/cmake/Modules/FindTinyXML2.cmake
+++ b/cmake/Modules/FindTinyXML2.cmake
@@ -82,7 +82,7 @@ endif()
 # https://github.com/gazebosim/gz-cmake/blob/gz-cmake4_4.1.0/cmake/FindTINYXML2.cmake
 # If that is the case (and we detect it by checking the value of CMAKE_FIND_PACKAGE_NAME)
 # we also define a TINYXML2::TINYXML2 target for gz-cmake compatibility
-if(CMAKE_FIND_PACKAGE_NAME STREQUAL "TINYXML2" NOT TARGET TINYXML2::TINYXML2)
+if(CMAKE_FIND_PACKAGE_NAME STREQUAL "TINYXML2" AND NOT TARGET TINYXML2::TINYXML2)
   add_library(TINYXML2::TINYXML2 INTERFACE IMPORTED)
   set_property(TARGET tinyxml2::tinyxml2 PROPERTY INTERFACE_LINK_LIBRARIES tinyxml2::tinyxml2)
 endif()

--- a/cmake/Modules/FindTinyXML2.cmake
+++ b/cmake/Modules/FindTinyXML2.cmake
@@ -82,7 +82,7 @@ endif()
 # https://github.com/gazebosim/gz-cmake/blob/gz-cmake4_4.1.0/cmake/FindTINYXML2.cmake
 # If that is the case (and we detect it by checking the value of CMAKE_FIND_PACKAGE_NAME)
 # we also define a TINYXML2::TINYXML2 target for gz-cmake compatibility
-if(CMAKE_FIND_PACKAGE_NAME STREQUAL "TINYXML2" AND NOT TARGET TINYXML2::TINYXML2)
+if(TARGET tinyxml2::tinyxml2 AND CMAKE_FIND_PACKAGE_NAME STREQUAL "TINYXML2" AND NOT TARGET TINYXML2::TINYXML2)
   add_library(TINYXML2::TINYXML2 INTERFACE IMPORTED)
   set_property(TARGET tinyxml2::tinyxml2 PROPERTY INTERFACE_LINK_LIBRARIES tinyxml2::tinyxml2)
 endif()

--- a/cmake/Modules/FindTinyXML2.cmake
+++ b/cmake/Modules/FindTinyXML2.cmake
@@ -76,3 +76,13 @@ endif()
 if(NOT TinyXML2_LIBRARIES)
   set(TinyXML2_LIBRARIES ${TINYXML2_LIBRARY})
 endif()
+
+# On case-insensitive filesystem, it is possible that FindTinyXML2.cmake is used if the caller
+# invoked find_package(TINYXML2), that is the signature used by gz-cmake, see
+# https://github.com/gazebosim/gz-cmake/blob/gz-cmake4_4.1.0/cmake/FindTINYXML2.cmake
+# If that is the case (and we detect it by checking the value of CMAKE_FIND_PACKAGE_NAME)
+# we also define a TINYXML2::TINYXML2 target for gz-cmake compatibility
+if(CMAKE_FIND_PACKAGE_NAME STREQUAL "TINYXML2" NOT TARGET TINYXML2::TINYXML2)
+  add_library(TINYXML2::TINYXML2 INTERFACE IMPORTED)
+  set_property(TARGET tinyxml2::tinyxml2 PROPERTY INTERFACE_LINK_LIBRARIES tinyxml2::tinyxml2)
+endif()


### PR DESCRIPTION
On case-insensitive filesystem, it is possible that FindTinyXML2.cmake is used if the caller invoked find_package(TINYXML2), that is the signature used by gz-cmake, see https://github.com/gazebosim/gz-cmake/blob/gz-cmake4_4.1.0/cmake/FindTINYXML2.cmake .

If that is the case (and we detect it by checking the value of CMAKE_FIND_PACKAGE_NAME) we also define a TINYXML2::TINYXML2 target for gz-cmake compatibility.

Without this fix, the configuration of `gz_ros2_control` on macOS when use a case insensitive filesystem fails with error:

~~~
2025-01-22T16:59:01.2739710Z  │ │ -- Configuring done (14.4s)
2025-01-22T16:59:01.3799310Z  │ │ CMake Error at $PREFIX/lib/cmake/gz-msgs10/gz-msgs10-targets.cmake:61 (set_target_properties):
2025-01-22T16:59:01.3800500Z  │ │   The link interface of target "gz-msgs10::gz-msgs10" contains:
2025-01-22T16:59:01.3801140Z  │ │     TINYXML2::TINYXML2
2025-01-22T16:59:01.3801480Z  │ │   but the target was not found.  Possible reasons include:
2025-01-22T16:59:01.3801840Z  │ │     * There is a typo in the target name.
2025-01-22T16:59:01.3802210Z  │ │     * A find_package call is missing for an IMPORTED target.
2025-01-22T16:59:01.3802560Z  │ │     * An ALIAS target is missing.
2025-01-22T16:59:01.3802930Z  │ │ Call Stack (most recent call first):
2025-01-22T16:59:01.3803250Z  │ │   $PREFIX/lib/cmake/gz-msgs10/gz-msgs10-config.cmake:126 (include)
2025-01-22T16:59:01.3803660Z  │ │   $PREFIX/lib/cmake/gz-transport13/gz-transport13-config.cmake:97 (find_package)
2025-01-22T16:59:01.3804050Z  │ │   $PREFIX/lib/cmake/gz-sim8/gz-sim8-config.cmake:94 (find_package)
2025-01-22T16:59:01.3804470Z  │ │   $PREFIX/opt/gz_sim_vendor/extra_cmake/lib/cmake/gz-sim/gz-sim-config.cmake:3 (find_package)
2025-01-22T16:59:01.3804820Z  │ │   CMakeLists.txt:28 (find_package)
2025-01-22T16:59:01.3805190Z  │ │ CMake Error at $PREFIX/lib/cmake/gz-gui8/gz-gui8-targets.cmake:61 (set_target_properties):
2025-01-22T16:59:01.3805630Z  │ │   The link interface of target "gz-gui8::gz-gui8" contains:
2025-01-22T16:59:01.3805940Z  │ │     TINYXML2::TINYXML2
2025-01-22T16:59:01.3806200Z  │ │   but the target was not found.  Possible reasons include:
2025-01-22T16:59:01.3806460Z  │ │     * There is a typo in the target name.
2025-01-22T16:59:01.3806720Z  │ │     * A find_package call is missing for an IMPORTED target.
2025-01-22T16:59:01.3806970Z  │ │     * An ALIAS target is missing.
2025-01-22T16:59:01.3807180Z  │ │ Call Stack (most recent call first):
2025-01-22T16:59:01.3807460Z  │ │   $PREFIX/lib/cmake/gz-gui8/gz-gui8-config.cmake:131 (include)
2025-01-22T16:59:01.3807800Z  │ │   $PREFIX/lib/cmake/gz-sim8/gz-sim8-config.cmake:98 (find_package)
2025-01-22T16:59:01.3808230Z  │ │   $PREFIX/opt/gz_sim_vendor/extra_cmake/lib/cmake/gz-sim/gz-sim-config.cmake:3 (find_package)
2025-01-22T16:59:01.3808570Z  │ │   CMakeLists.txt:28 (find_package)
2025-01-22T16:59:01.4087500Z  │ │ -- Generating done (0.1s)
~~~